### PR TITLE
Added step on how to register the protocol

### DIFF
--- a/README.org
+++ b/README.org
@@ -40,7 +40,11 @@ end open location
   </array>
 #+END_SRC
 
-** Step 3. Test your results
+** Step 3. Install the protocol
+
+To register the protocol, just click on the =org-protocol.app=.
+
+** Step 4. Test your results
 
 See http://orgmode.org/worg/org-contrib/org-protocol.html#orgheadline8
 


### PR DESCRIPTION
The README is currently missing the minor step of actually registering the protocol so the browser knows how to handle it. Added this to the README.